### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main", "develop" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/swapnilgai/basshead/security/code-scanning/1](https://github.com/swapnilgai/basshead/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function correctly. Since the workflow primarily involves reading code, setting up the environment, and running build tasks, the `contents: read` permission is sufficient. This ensures that the `GITHUB_TOKEN` has only read access to the repository contents, reducing the risk of unauthorized modifications.

The `permissions` block should be added at the root level of the workflow file to apply to all jobs in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
